### PR TITLE
solve some problems with encode in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,12 @@
 # along with this programe.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import io
 from setuptools import setup, find_packages
 
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    return io.open(os.path.join(os.path.dirname(__file__), *rnames), encoding='utf-8').read()
 
 setup(
     name="django-inplaceedit",


### PR DESCRIPTION
We need io.open() -Python 3's default open- to specify file utf-8 encoding
If we didn't have utf-8 as LANG env variable python open read as ASCII and the accent in line 24 of 'CHANGES.rst' : " \* Jón Levy" causes and ASCII error
